### PR TITLE
Fix wrong event name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ The following properties can be applied on top of the [common Tabris.js properti
 
 ### Events
 
-#### change:date
+#### dateChanged
 
-The `change:date` is fired when a user selects a date in the calendar widget.
+Fired when the user selects a date in the calendar widget.
 
 ##### Event parameter
 * `event.value`: _number_


### PR DESCRIPTION
As of Tabris.js 2.0 stable, change event naming follows the convention
'propertyChanged' instead of 'change:property'.